### PR TITLE
Grammar Problem: The first rule must not be a fragment

### DIFF
--- a/org.xtext.grammars/org.xtext.base/genericDatasheet/org.xtext.base.genericDatasheet/src/org/xtext/base/genericDatasheet/GenericDatasheet.xtext
+++ b/org.xtext.grammars/org.xtext.base/genericDatasheet/org.xtext.base.genericDatasheet/src/org/xtext/base/genericDatasheet/GenericDatasheet.xtext
@@ -48,6 +48,9 @@ grammar org.xtext.base.genericDatasheet.GenericDatasheet with org.eclipse.xtext.
 import "http://www.ecore.org/base/genericDatasheet" 
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
+AbstractLicense returns AbstractLicense:
+	SpdxLicense | ProprietaryLicense;
+
 fragment GenericDatasheet returns GenericDatasheet:
 	(
 		('baseURI' (':')? baseURI=EString) &
@@ -62,8 +65,6 @@ fragment GenericDatasheet returns GenericDatasheet:
 	
 terminal TEXT_BLOCK returns ecore::EString: '$%' -> '%$';
 
-AbstractLicense returns AbstractLicense:
-	SpdxLicense | ProprietaryLicense;
 
 EString returns ecore::EString:
 	STRING;


### PR DESCRIPTION
I have always get an error by importing the project `org.xtext.base.genericDatasheet` that was:

`The first rule must not be a fragment`

This can be solved by just defining first a rule call