### PR TITLE
extend the activity generator extension to allow the autogeneration o…

### DIFF
--- a/org.xtend.generators/org.xtend.smartsoft.generator/src/org/xtend/smartsoft/generator/component/ActivityGeneratorExtension.xtend
+++ b/org.xtend.generators/org.xtend.smartsoft.generator/src/org/xtend/smartsoft/generator/component/ActivityGeneratorExtension.xtend
@@ -134,4 +134,38 @@ interface ActivityGeneratorExtension {
 	 * @result the update code as a character stream 
 	 */
 	def CharSequence getUpdateValuesImplementation(Activity activity) ''''''
+	
+	/**
+	 * This optional method places provided sniplet into the <b>update method</b> 
+	 * of the activity that is called at the beginning of every activity's
+	 * task cycle and is supposed to update the values of all the input
+	 * variables (i.e. class members). 
+	 * 
+	 * @param activity the calling Activity definition resource
+	 * @result the update code as a character stream 
+	 */
+	def CharSequence getUserHeaderIncludes(Activity activity) ''''''
+	
+	/**
+	 * This optional method places provided sniplet into the <b>update method</b> 
+	 * of the activity that is called at the beginning of every activity's
+	 * task cycle and is supposed to update the values of all the input
+	 * variables (i.e. class members). 
+	 * 
+	 * @param activity the calling Activity definition resource
+	 * @result the update code as a character stream 
+	 */
+	def CharSequence getUserClassMemberPublicDefinition(Activity activity) ''''''
+			
+	/**
+	 * This optional method places provided sniplet into the <b>update method</b> 
+	 * of the activity that is called at the beginning of every activity's
+	 * task cycle and is supposed to update the values of all the input
+	 * variables (i.e. class members). 
+	 * 
+	 * @param activity the calling Activity definition resource
+	 * @result the update code as a character stream 
+	 */		
+	def CharSequence getUserSourceImplementation(Activity activity) ''''''
+		
 }

--- a/org.xtend.generators/org.xtend.smartsoft.generator/src/org/xtend/smartsoft/generator/component/SmartTask.xtend
+++ b/org.xtend.generators/org.xtend.smartsoft.generator/src/org/xtend/smartsoft/generator/component/SmartTask.xtend
@@ -377,6 +377,9 @@ class SmartTask {
 		#define _«task.nameClass.toUpperCase»_HH
 		
 		#include "«task.TaskHeaderFileName»"
+		«FOR ext: activityGeneratorExtensions»
+		«ext.getUserHeaderIncludes(task)»
+		«ENDFOR»
 		
 		class «task.nameClass»  : public «task.nameClass»Core
 		{
@@ -394,6 +397,9 @@ class SmartTask {
 			virtual int on_entry();
 			virtual int on_execute();
 			virtual int on_exit();
+			«FOR ext: activityGeneratorExtensions»
+			«ext.getUserClassMemberPublicDefinition(task)»
+			«ENDFOR»
 		};
 		
 		#endif
@@ -438,7 +444,9 @@ class SmartTask {
 			//   there, use the method «inLink.inputPort.nameInstance»GetUpdate(input) to get a copy of the input object
 		}
 		«ENDFOR»
-		
+		«FOR ext: activityGeneratorExtensions»
+		«ext.getUserSourceImplementation(task)»
+		«ENDFOR»
 		int «task.nameClass»::on_entry()
 		{
 			// do initialization procedures here, which are called once, each time the task is started


### PR DESCRIPTION
…f user code


With the current approach the extensions are only allow the create code on the src-gen folder, code that if modified is not protected. For some Mixed Ports cases this is not enough, please check https://github.com/seronet-project/SeRoNet-Tooling-ROS-Mixed-Port/pull/30 for further details.

These modifications only add new optional methods, *can't break* for other non-ROS mixed port cases